### PR TITLE
Expose Pipe{Reader|Writer} and their Close[WithError] methods, like io.Pipe

### DIFF
--- a/nio.go
+++ b/nio.go
@@ -22,10 +22,10 @@ type Buffer interface {
 // Close will complete once pending I/O is done. Buffered data will still be available to Read
 // after the Writer has been closed. Parallel calls to Read, and parallel calls to Write are also safe :
 // the individual calls will be gated sequentially.
-func Pipe(buf Buffer) (r io.ReadCloser, w io.WriteCloser) {
+func Pipe(buf Buffer) (r *PipeReader, w *PipeWriter) {
 	p := newBufferedPipe(buf)
-	r = &bufPipeReader{bufpipe: p}
-	w = &bufPipeWriter{bufpipe: p}
+	r = &PipeReader{bufpipe: p}
+	w = &PipeWriter{bufpipe: p}
 	return r, w
 }
 
@@ -45,7 +45,7 @@ func NewReader(src io.Reader, buf Buffer) io.ReadCloser {
 
 	go func() {
 		_, err := io.Copy(w, src)
-		w.(*bufPipeWriter).CloseWithErr(err)
+		w.CloseWithError(err)
 	}()
 
 	return r


### PR DESCRIPTION
This allows library users to access the Close methods without funny interface assertions, and replicate functionality similar (but not identical) to NewReader.  It also mirrors the io.Pipe implementation, and follows the general best practice of returning concretes instead of interfaces.

This does change an exposed API, but in such a way that should not break most existing code, as shown by the unchanged tests.

For example, this lets me do this:

```go
	// Concurrently download the archive to a memory buffer of 1MB chunks
	buf := buffer.NewPartition(buffer.NewMemPool(1024 * 1024))
	pr, pw := nio.Pipe(buf)
	go func() {
		_, err := io.Copy(pw, r.Body)
		pw.CloseWithError(err)
		r.Body.Close()
	}()
	return pr, nil
```

By the way, thanks a lot for the library, I was about to reimplement the exact same thing.