### PR TITLE
ensure copy of p when Writing stays within bounds

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -131,8 +131,14 @@ func (w *PipeWriter) Write(p []byte) (n int, err error) {
 				w.c.Wait()
 			}
 
-			// chunk write to fill space
-			m, err = w.b.Write(p[n : int64(n)+gap(w.b)])
+			// now that we have the lock, see what the real gap is
+			nn := int64(n) + gap(w.b)
+			if nn > int64(len(p)) {
+				// it's grown enough, just do a standard write
+				break
+			}
+
+			m, err = w.b.Write(p[n:nn])
 			n += m
 			if err != nil {
 				return n, err


### PR DESCRIPTION
I believe calling gap can race which can cause trying to access beyond the end of p. This came about via https://github.com/oklog/oklog/issues/16.

With this patch I can run my test setup indefinitely. I also had debugging inside the if body which showed this at work:

```
len(p)=30 n=0 gap(w.b)=1048576 nn=30
len(p)=30 n=0 gap(w.b)=1048576 nn=30
len(p)=30 n=0 gap(w.b)=1048576 nn=30
len(p)=30 n=0 gap(w.b)=1048576 nn=30
len(p)=30 n=0 gap(w.b)=1048576 nn=30
len(p)=30 n=0 gap(w.b)=1048576 nn=30
len(p)=30 n=0 gap(w.b)=1048576 nn=30
len(p)=30 n=0 gap(w.b)=1048576 nn=30
len(p)=30 n=0 gap(w.b)=1048576 nn=30
len(p)=30 n=0 gap(w.b)=1048576 nn=30
len(p)=30 n=0 gap(w.b)=1048576 nn=30
```